### PR TITLE
hatch-dependency-coversion: new project

### DIFF
--- a/.github/workflows/publish-hatch-dependency-coversion.yml
+++ b/.github/workflows/publish-hatch-dependency-coversion.yml
@@ -1,0 +1,26 @@
+name: 'publish hatch-dependency-coversion'
+on:
+  push:
+    tags:
+      - 'hatch-dependency-coversion@*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: hatch-dependency-coversion-pypi-release
+      url: https://pypi.org/p/hatch-dependency-tunable
+    permissions:
+      id-token: write
+    steps:
+    - name: Fetch source for package build
+      uses: actions/checkout@v3
+    - name: Build distribution
+      run: |
+        hatch build
+      working-directory:
+        hatch-dependency-coversion
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: hatch-dependency-coversion/dist

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       HATCH_VCS_TUNABLE_DIFF: ${{ steps.hatch-vcs-tunable-diff.outputs.HATCH_VCS_TUNABLE_DIFF }}
+      HATCH_DEPENDENCY_COVERSION_DIFF: ${{ steps.hatch-dependency-coversion-diff.outputs.HATCH_DEPENDENCY_COVERSION_DIFF }}
     steps:
       - name: Fetch repo for diffing
         uses: actions/checkout@v3
@@ -23,13 +24,33 @@ jobs:
         id: hatch-vcs-tunable-diff
         run: |
           echo "HATCH_VCS_TUNABLE_DIFF=\"${GIT_DIFF_FILTERED}\"" >> $GITHUB_OUTPUT
+      - name: Check if dependency-coversion analysis changed
+        uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            hatch-dependency-coversion/**/*
+            hatch-dependency-coversion/**/.*
+      - name: Set diff output for hatch-dependency-coversion
+        id: hatch-dependency-coversion-diff
+        run: |
+          echo "HATCH_DEPENDENCY_COVERSION_DIFF=\"${GIT_DIFF_FILTERED}\"" >> $GITHUB_OUTPUT
   hatch-vcs-tunable-analysis:
     runs-on: ubuntu-latest
     needs: [which-paths]
-    if: ${{ needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF }}
+    if: ${{ needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF != '""' }}
     steps:
       - name: Ask for news fragments
         if: ${{ !contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'changelog.d') }}
         run: |
-          echo 'Please add a news fragment for your change.'
+          echo 'Please add a news fragment for your change to hatch-vcs-tunable.'
+          exit 1
+  hatch-dependency-coversion-analysis:
+    runs-on: ubuntu-latest
+    needs: [which-paths]
+    if: ${{ needs.which-paths.outputs.HATCH_DEPENDENCY_COVERSION_DIFF != '""' }}
+    steps:
+      - name: Ask for news fragments
+        if: ${{ !contains(needs.which-paths.outputs.HATCH_DEPENDENCY_COVERSION_DIFF, 'changelog.d') }}
+        run: |
+          echo 'Please add a news fragment for your change to hatch-dependency-coversion.'
           exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       HATCH_VCS_TUNABLE_DIFF: ${{ steps.hatch-vcs-tunable-diff.outputs.HATCH_VCS_TUNABLE_DIFF }}
+      HATCH_DEPENDENCY_COVERSION_DIFF: ${{ steps.hatch-dependency-coversion-diff.outputs.HATCH_DEPENDENCY_COVERSION_DIFF }}
       MANAGEMENT_DIFF: ${{ steps.management-diff.outputs.MANAGEMENT_DIFF }}
     steps:
       - name: Fetch repo for diffing
@@ -30,6 +31,18 @@ jobs:
         id: hatch-vcs-tunable-diff
         run: |
           echo "HATCH_VCS_TUNABLE_DIFF=\"$(echo ${GIT_DIFF_FILTERED} | sed 's/ *$//')\"" >> $GITHUB_OUTPUT
+      - name: Check if dependency-coversion-analysis changed
+        uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            hatch-dependency-coversion/**/*
+            hatch-dependency-coversion/**/.*
+          FILES: |
+            .github/workflows/pull-request.yml
+      - name: Set diff output for hatch-dependency-coversion
+        id: hatch-dependency-coversion-diff
+        run: |
+          echo "HATCH_DEPENDENCY_COVERSION_DIFF=\"$(echo ${GIT_DIFF_FILTERED} | sed 's/ *$//')\"" >> $GITHUB_OUTPUT
       - name: Check if repo management changed
         uses: technote-space/get-diff-action@v6
         with:
@@ -38,6 +51,7 @@ jobs:
             .*
             .*/**/*
             !hatch-vcs-tunable/**/*
+            !hatch-dependency-coversion/**/*
       - name: Set diff output for management
         id: management-diff
         run: |
@@ -99,3 +113,60 @@ jobs:
       - name: Run all tests
         run: hatch run test:test
         working-directory: hatch-vcs-tunable
+
+  hatch-dependency-coversion-analysis:
+    if: ${{ needs.which-paths.outputs.HATCH_DEPENDENCY_COVERSION_DIFF != '""' }}
+    runs-on: ubuntu-latest
+    needs: [which-paths]
+    steps:
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Set up python environment
+        run: |
+          python -m pip install pipx
+          pipx install hatch
+      - name: Fetch repo
+        uses: actions/checkout@v3
+      - name: Create default env
+        run: hatch env create default
+        working-directory: hatch-dependency-coversion
+      - name: Check formatting
+        run: hatch run format --check
+        working-directory: hatch-dependency-coversion
+      - name: Lint
+        run: hatch run lint
+        working-directory: hatch-dependency-coversion
+      - name: Check types
+        run: hatch run check
+        working-directory: hatch-dependency-coversion
+      - name: Quick tests
+        run: hatch run test
+        working-directory: hatch-dependency-coversion
+
+  hatch-dependency-coversion-tests:
+    if: ${{ needs.which-paths.outputs.HATCH_DEPENDENCY_COVERSION_DIFF != '""' }}
+    needs: [which-paths, hatch-dependency-coversion-analysis]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Set up python environment
+        run: |
+          python -m pip install pipx
+          pipx install hatch
+      - name: Fetch repo
+        uses: actions/checkout@v3
+      - name: Create test env
+        run: hatch env create test
+        working-directory: hatch-dependency-coversion
+      - name: Run all tests
+        run: hatch run test:test
+        working-directory: hatch-dependency-coversion

--- a/hatch-dependency-coversion/.gitignore
+++ b/hatch-dependency-coversion/.gitignore
@@ -1,0 +1,2 @@
+**/_version.py
+dist/

--- a/hatch-dependency-coversion/LICENSE
+++ b/hatch-dependency-coversion/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/hatch-dependency-coversion/README.md
+++ b/hatch-dependency-coversion/README.md
@@ -1,0 +1,76 @@
+# hatch-dependency-coversion
+
+[![PyPI - Version](https://img.shields.io/pypi/v/hatch-dependency-coversion.svg)](https://pypi.org/project/hatch-dependency-coversion)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hatch-dependency-coversion.svg)](https://pypi.org/project/hatch-dependency-coversion)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
+
+-----
+
+This is a plugin for [Hatch](https://github.com/pypa/hatch) that allows you to rewrite the versions in selected dependency specifiers to be exactly the same as the current version of the project configured in `pyproject.toml`'s `[project]` table, requiring exact coversioning of those dependencies with the project.
+
+This is useful for projects that are developed in lockstep but distributed as independent python packages rather than as subcomponents of the same namespace package. It is the equivalent of the following `setup.py`:
+
+``` python
+VERSION = '1.0.0'
+setup(name='my-project', version=VERSION, install_requires=[f'my-dependency=={VERSION}'])
+```
+
+Minimal configuration is done in your `pyproject.toml` like this:
+
+``` toml
+# Since this is a plugin for hatchling, you must be using hatchling as your build backend 
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my-project"
+version = "0.1.0"
+dependencies = [
+    "my-dependency==0.0.0"  # 0.0.0 is chosen at random and will be overwritten
+]
+[tool.hatch.metadata.hooks.dependency-coversion]
+override-versions-of = ["my-dependency"]  # this list contains the names of dependencies to override
+```
+
+**Table of Contents**
+
+- [Operation](#operation)
+- [Use as a plugin](#plugin)
+- [Configuration](#configuration)
+- [License](#license)
+
+## Operation
+
+`hatch-dependency-coversion` is a metadata hook for `hatch`, or more specifically for `hatchling`, the PEP-508 build backend written by the `hatch` team. Whenever a package that uses `hatch-dependency-coversion` is built, `hatch-dependency-coversion` gets the chance to alter the list of dependencies the package will specify as required, and that `pip` and other installers or environment creators use to determine what dependencies to install.
+
+Only those dependencies identified by name in the `tool.hatch.metadata.hooks.dependency-coversion.override-versions-of` list will have their versions overridden; nothing else will be touched.
+
+Any PEP-440 version specifiers other than the version are left untouched; you can use `hatch-dependency-coversion` on dependencies that are optionally installed with markers (i.e. with `os_name == 'Windows'` or similar) and the markers will be preserved.
+
+
+## Plugin
+
+Ensure `hatch-dependency-coversion` is listed in the `build-system.requires` field in your `pyproject.toml`:
+
+``` toml
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+```
+
+## Configuration
+
+`hatch-dependency-coversion` is configured through `pyproject.toml` as a metadata hook in a similar way to other hatch plugins. Its plugin name is `dependency-coversion`:
+
+``` toml
+[tool.hatch.metadata.hooks.dependency-coversion]
+override-versions-of = ["dependency1", "dependency2"]
+```
+
+The `override-versions-of` key is the only configuration that `hatch-dependency-coversion` takes. It is a list of strings, each of which should be the package name (the same thing you'd pass to `pip` or list in a dependency specifier) of one of the dependencies. Anything in here that is not in the top level `project.dependencies` key is ignored.
+
+## License
+
+`hatch-dependency-coversion` is distributed under the terms of the [Apache-2.0](https://spdx.org/licenses/Apache-2.0.html) license.

--- a/hatch-dependency-coversion/README.md
+++ b/hatch-dependency-coversion/README.md
@@ -19,8 +19,8 @@ setup(name='my-project', version=VERSION, install_requires=[f'my-dependency=={VE
 Minimal configuration is done in your `pyproject.toml` like this:
 
 ``` toml
-# Since this is a plugin for hatchling, you must be using hatchling as your build backend 
 [build-system]
+# Since this is a plugin for hatchling, you must be using hatchling as your build backend
 requires = ["hatchling", "hatch-dependency-coversion"]
 build-backend = "hatchling.build"
 
@@ -28,10 +28,12 @@ build-backend = "hatchling.build"
 name = "my-project"
 version = "0.1.0"
 dependencies = [
-    "my-dependency==0.0.0"  # 0.0.0 is chosen at random and will be overwritten
+    # 0.0.0 is chosen at random and will be overwritten
+    "my-dependency==0.0.0"
 ]
 [tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of = ["my-dependency"]  # this list contains the names of dependencies to override
+# this list contains the names of dependencies to override
+override-versions-of = ["my-dependency"]
 ```
 
 **Table of Contents**

--- a/hatch-dependency-coversion/changelog.d/.gitignore
+++ b/hatch-dependency-coversion/changelog.d/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/hatch-dependency-coversion/pyproject.toml
+++ b/hatch-dependency-coversion/pyproject.toml
@@ -1,0 +1,154 @@
+[build-system]
+requires = ["hatchling==1.21.1", "hatch-vcs==0.4.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hatch-dependency-coversion"
+dynamic = ["version"]
+description = "Require that specific dependencies of your package are exactly coversioned."
+readme = "README.md"
+requires-python = ">=3.8"
+license = "Apache-2.0"
+keywords = ["hatch", "version", "coversioning", "monorepo"]
+authors = [
+  { name = "Opentrons Engineering", email = "engineering@opentrons.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Framework :: Hatch"
+]
+dependencies = ["hatchling>1.0.0,<2.0.0", "packaging>=22.0"]
+
+[project.entry-points.hatch]
+dependency-coversion = "hatch_dependency_coversion.hooks"
+
+[project.urls]
+Documentation = "https://github.com/Opentrons/hatch-plugins/tree/main/hatch-dependency-coversion#readme"
+Issues = "https://github.com/Opentrons/hatch-plugins/issues"
+Source = "https://github.com/Opentrons/hatch-plugins"
+Changelog = "https://github.com/Opentrons/hatch-plugins/tree/main/hatch-dependency-coversion/CHANGES.md"
+
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "0.0.0-dev"
+tag-pattern = "hatch-dependency-coversion@(?P<version>)"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/hatch_dependency_coversion/_version.py"
+
+[tool.hatch.envs.maintenance]
+dependencies = [
+  "towncrier"
+]
+
+[tool.hatch.envs.maintenance.scripts]
+changes-new = "towncrier create {args}"
+changes-build = "towncrier build {args}"
+
+[tool.hatch.envs.test]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest~=8.0.1",
+  "build",
+  "pkginfo",
+]
+[tool.hatch.envs.test.scripts]
+test = "pytest {args:tests}"
+test-cov = "coverage run -m pytest {args:tests}"
+cov-report = [
+  "- coverage combine",
+  "coverage report",
+]
+cov = [
+  "test-cov",
+  "cov-report",
+]
+
+[tool.hatch.envs.test.overrides]
+name."py*-1.0.0".dependencies = ["hatchling==1.0.0"]
+name."py*-1.21.1".dependencies = ["hatchling==1.21.1"]
+name."py*-latest".dependencies = ["hatchling"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+hatchling = ["1.0.0", "1.21.1", "latest"]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest~=8.0.1",
+  "mypy==1.8.0",
+  "ruff==0.2.2",
+  "build",
+  "pkginfo",
+]
+
+[tool.hatch.envs.default.scripts]
+check = "mypy --install-types --non-interactive {args:src/hatch_dependency_coversion tests}"
+format = "ruff format {args:src/hatch_dependency_coversion tests}"
+lint = "ruff check {args:src/hatch_dependency_coversion tests}"
+test = "pytest {args:tests}"
+
+[tool.coverage.run]
+source_pkgs = ["hatch_dependency_coversion", "tests"]
+branch = true
+parallel = true
+
+[tool.coverage.paths]
+hatch_dependency_coversion = ["src/hatch_dependency_coversion", "*/hatch-dependency-coversion/src/hatch_dependency_coversion"]
+tests = ["tests", "*/hatch-dependency-coversion/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]
+
+[tool.towncrier]
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+title_format = "## [{version}](https://github.com/opentrons/hatch-plugins/tree/{version}/hatch-dependency-coversion) - {project_date}"
+issue_format = "[#{issue}](https://github.com/opentrons/hatch-plugins/issues/{issue})"
+package = "hatch_dependency_coversion"
+package_dir = "src"
+directory = "changelog.d"
+filename = "CHANGES.md"
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true

--- a/hatch-dependency-coversion/src/hatch_dependency_coversion/__init__.py
+++ b/hatch-dependency-coversion/src/hatch_dependency_coversion/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024-present Seth Foster <seth@opentrons.com>
+#
+# SPDX-License-Identifier: MIT
+
+from ._version import __version__, __version_tuple__
+
+__all__ = ["__version__", "__version_tuple__"]

--- a/hatch-dependency-coversion/src/hatch_dependency_coversion/const.py
+++ b/hatch-dependency-coversion/src/hatch_dependency_coversion/const.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024-present Opentrons Engineering <engineering@opentrons.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Final
+
+PLUGIN_NAME: Final = "dependency-coversion"

--- a/hatch-dependency-coversion/src/hatch_dependency_coversion/hooks.py
+++ b/hatch-dependency-coversion/src/hatch_dependency_coversion/hooks.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024-present Opentrons Engineering <engineering@opentrons.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registers a hatch metadata hook for altering dependency versions."""
+
+from hatchling.plugin import hookimpl
+from .metadata_hook import DependencyCoversionMetadataHook
+
+
+@hookimpl
+def hatch_register_metadata_hook():
+    return DependencyCoversionMetadataHook

--- a/hatch-dependency-coversion/src/hatch_dependency_coversion/metadata_hook.py
+++ b/hatch-dependency-coversion/src/hatch_dependency_coversion/metadata_hook.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2024-present Opentrons Engineering <engineering@opentrons.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A metadata hook for hatchling that can force dependencies to be coversioned."""
+from __future__ import annotations
+from typing import Any
+
+from packaging.requirements import Requirement, SpecifierSet
+
+from hatchling.metadata.plugin.interface import MetadataHookInterface
+from hatch_dependency_coversion.const import PLUGIN_NAME as _PLUGIN_NAME
+
+
+class DependencyCoversionMetadataHook(MetadataHookInterface):
+    PLUGIN_NAME = _PLUGIN_NAME
+
+    def _maybe_update_dep(
+        self, depspec: str, version: str, which_dependencies: list[str]
+    ) -> str:
+        requirement = Requirement(depspec)
+        if requirement.name not in which_dependencies:
+            return depspec
+        requirement.specifier = SpecifierSet(f"=={version}")
+        return str(requirement)
+
+    def _update_dependency_versions(
+        self,
+        dependencies_metadata: list[str],
+        version: str,
+        which_dependencies: list[str],
+    ) -> list[str]:
+        """Do the actual dependency update"""
+        return [
+            self._maybe_update_dep(depspec, version, which_dependencies)
+            for depspec in dependencies_metadata
+        ]
+
+    def update(self, metadata: dict[str, Any]) -> None:
+        """Update metadata for coversioning."""
+        metadata["dependencies"] = self._update_dependency_versions(
+            metadata.get("dependencies", []),
+            metadata["version"],
+            self.config.get("override-versions-of", []),
+        )

--- a/hatch-dependency-coversion/tests/__init__.py
+++ b/hatch-dependency-coversion/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Seth Foster <seth@opentrons.com>
+#
+# SPDX-License-Identifier: MIT

--- a/hatch-dependency-coversion/tests/conftest.py
+++ b/hatch-dependency-coversion/tests/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from textwrap import dedent
 from pathlib import Path
 import pytest
 
@@ -19,16 +20,18 @@ def static_requirements() -> list[str]:
 @pytest.fixture
 def unconfigured_project(tmp_path: Path, static_requirements: list[str]) -> Path:
     (tmp_path / "pyproject.toml").write_text(
-        f"""
-[build-system]
-requires = ["hatchling", "hatch-dependency-coversion"]
-build-backend = "hatchling.build"
-[project]
-name = "unconfigured-project"
-version = "0.1.0"
-dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
-[tool.hatch.metadata.hooks.dependency-coversion]
-"""
+        dedent(
+            f"""
+        [build-system]
+        requires = ["hatchling", "hatch-dependency-coversion"]
+        build-backend = "hatchling.build"
+        [project]
+        name = "unconfigured-project"
+        version = "0.1.0"
+        dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+        [tool.hatch.metadata.hooks.dependency-coversion]
+        """
+        )
     )
     (tmp_path / "unconfigured_project").mkdir()
     (tmp_path / "unconfigured_project" / "__init__.py").write_text("")
@@ -40,17 +43,19 @@ def requests_zero_coversions_project(
     tmp_path: Path, static_requirements: list[str]
 ) -> Path:
     (tmp_path / "pyproject.toml").write_text(
-        f"""
-[build-system]
-requires = ["hatchling", "hatch-dependency-coversion"]
-build-backend = "hatchling.build"
-[project]
-name = "zero-coversions-project"
-version = "0.1.0"
-dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
-[tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of=[]
-"""
+        dedent(
+            f"""
+        [build-system]
+        requires = ["hatchling", "hatch-dependency-coversion"]
+        build-backend = "hatchling.build"
+        [project]
+        name = "zero-coversions-project"
+        version = "0.1.0"
+        dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+        [tool.hatch.metadata.hooks.dependency-coversion]
+        override-versions-of=[]
+        """
+        )
     )
     (tmp_path / "zero_coversions_project").mkdir()
     (tmp_path / "zero_coversions_project" / "__init__.py").write_text("")
@@ -62,17 +67,19 @@ def requests_coversion_of_open_version_project(
     tmp_path: Path, static_requirements: list[str]
 ) -> Path:
     (tmp_path / "pyproject.toml").write_text(
-        f"""
-[build-system]
-requires = ["hatchling", "hatch-dependency-coversion"]
-build-backend = "hatchling.build"
-[project]
-name = "coversion-of-open-version-project"
-version = "0.1.0"
-dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
-[tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of=["dependency1"]
-"""
+        dedent(
+            f"""
+        [build-system]
+        requires = ["hatchling", "hatch-dependency-coversion"]
+        build-backend = "hatchling.build"
+        [project]
+        name = "coversion-of-open-version-project"
+        version = "0.1.0"
+        dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+        [tool.hatch.metadata.hooks.dependency-coversion]
+        override-versions-of=["dependency1"]
+        """
+        )
     )
     (tmp_path / "coversion_of_open_version_project").mkdir()
     (tmp_path / "coversion_of_open_version_project" / "__init__.py").write_text("")
@@ -84,17 +91,19 @@ def requests_coversion_of_specified_version_project(
     tmp_path: Path, static_requirements: list[str]
 ) -> Path:
     (tmp_path / "pyproject.toml").write_text(
-        f"""
-[build-system]
-requires = ["hatchling", "hatch-dependency-coversion"]
-build-backend = "hatchling.build"
-[project]
-name = "coversion-of-specified-version-project"
-version = "0.1.0"
-dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
-[tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of=["dependency2"]
-"""
+        dedent(
+            f"""
+        [build-system]
+        requires = ["hatchling", "hatch-dependency-coversion"]
+        build-backend = "hatchling.build"
+        [project]
+        name = "coversion-of-specified-version-project"
+        version = "0.1.0"
+        dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+        [tool.hatch.metadata.hooks.dependency-coversion]
+        override-versions-of=["dependency2"]
+        """
+        )
     )
     (tmp_path / "coversion_of_specified_version_project").mkdir()
     (tmp_path / "coversion_of_specified_version_project" / "__init__.py").write_text("")
@@ -106,17 +115,19 @@ def requests_coversion_of_marked_version_project(
     tmp_path: Path, static_requirements: list[str]
 ) -> Path:
     (tmp_path / "pyproject.toml").write_text(
-        f"""
-[build-system]
-requires = ["hatchling", "hatch-dependency-coversion"]
-build-backend = "hatchling.build"
-[project]
-name = "coversion-of-marked-version-project"
-version = "0.1.0"
-dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
-[tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of=["dependency3"]
-"""
+        dedent(
+            f"""
+        [build-system]
+        requires = ["hatchling", "hatch-dependency-coversion"]
+        build-backend = "hatchling.build"
+        [project]
+        name = "coversion-of-marked-version-project"
+        version = "0.1.0"
+        dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+        [tool.hatch.metadata.hooks.dependency-coversion]
+        override-versions-of=["dependency3"]
+        """
+        )
     )
     (tmp_path / "coversion_of_marked_version_project").mkdir()
     (tmp_path / "coversion_of_marked_version_project" / "__init__.py").write_text("")
@@ -126,17 +137,19 @@ override-versions-of=["dependency3"]
 @pytest.fixture
 def requests_multiple_project(tmp_path: Path, static_requirements: list[str]) -> Path:
     (tmp_path / "pyproject.toml").write_text(
-        f"""
-[build-system]
-requires = ["hatchling", "hatch-dependency-coversion"]
-build-backend = "hatchling.build"
-[project]
-name = "coversion-of-multiple-project"
-version = "0.1.0"
-dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
-[tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of=["dependency2", "dependency1", "dependency3"]
-"""
+        dedent(
+            f"""
+        [build-system]
+        requires = ["hatchling", "hatch-dependency-coversion"]
+        build-backend = "hatchling.build"
+        [project]
+        name = "coversion-of-multiple-project"
+        version = "0.1.0"
+        dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+        [tool.hatch.metadata.hooks.dependency-coversion]
+        override-versions-of=["dependency2", "dependency1", "dependency3"]
+        """
+        )
     )
     (tmp_path / "coversion_of_multiple_project").mkdir()
     (tmp_path / "coversion_of_multiple_project" / "__init__.py").write_text("")

--- a/hatch-dependency-coversion/tests/conftest.py
+++ b/hatch-dependency-coversion/tests/conftest.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2024-present Opentrons Engineering <engineering@opentrons.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def static_requirements() -> list[str]:
+    return [
+        "dependency1",
+        "dependency2==10.10.2",
+        "dependency3>=0.2.81; os_name == 'Windows'",
+    ]
+
+
+@pytest.fixture
+def unconfigured_project(tmp_path: Path, static_requirements: list[str]) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+[project]
+name = "unconfigured-project"
+version = "0.1.0"
+dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+[tool.hatch.metadata.hooks.dependency-coversion]
+"""
+    )
+    (tmp_path / "unconfigured_project").mkdir()
+    (tmp_path / "unconfigured_project" / "__init__.py").write_text("")
+    return tmp_path
+
+
+@pytest.fixture
+def requests_zero_coversions_project(
+    tmp_path: Path, static_requirements: list[str]
+) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+[project]
+name = "zero-coversions-project"
+version = "0.1.0"
+dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+[tool.hatch.metadata.hooks.dependency-coversion]
+override-versions-of=[]
+"""
+    )
+    (tmp_path / "zero_coversions_project").mkdir()
+    (tmp_path / "zero_coversions_project" / "__init__.py").write_text("")
+    return tmp_path
+
+
+@pytest.fixture
+def requests_coversion_of_open_version_project(
+    tmp_path: Path, static_requirements: list[str]
+) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+[project]
+name = "coversion-of-open-version-project"
+version = "0.1.0"
+dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+[tool.hatch.metadata.hooks.dependency-coversion]
+override-versions-of=["dependency1"]
+"""
+    )
+    (tmp_path / "coversion_of_open_version_project").mkdir()
+    (tmp_path / "coversion_of_open_version_project" / "__init__.py").write_text("")
+    return tmp_path
+
+
+@pytest.fixture
+def requests_coversion_of_specified_version_project(
+    tmp_path: Path, static_requirements: list[str]
+) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+[project]
+name = "coversion-of-specified-version-project"
+version = "0.1.0"
+dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+[tool.hatch.metadata.hooks.dependency-coversion]
+override-versions-of=["dependency2"]
+"""
+    )
+    (tmp_path / "coversion_of_specified_version_project").mkdir()
+    (tmp_path / "coversion_of_specified_version_project" / "__init__.py").write_text("")
+    return tmp_path
+
+
+@pytest.fixture
+def requests_coversion_of_marked_version_project(
+    tmp_path: Path, static_requirements: list[str]
+) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+[project]
+name = "coversion-of-marked-version-project"
+version = "0.1.0"
+dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+[tool.hatch.metadata.hooks.dependency-coversion]
+override-versions-of=["dependency3"]
+"""
+    )
+    (tmp_path / "coversion_of_marked_version_project").mkdir()
+    (tmp_path / "coversion_of_marked_version_project" / "__init__.py").write_text("")
+    return tmp_path
+
+
+@pytest.fixture
+def requests_multiple_project(tmp_path: Path, static_requirements: list[str]) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        f"""
+[build-system]
+requires = ["hatchling", "hatch-dependency-coversion"]
+build-backend = "hatchling.build"
+[project]
+name = "coversion-of-multiple-project"
+version = "0.1.0"
+dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements])}]
+[tool.hatch.metadata.hooks.dependency-coversion]
+override-versions-of=["dependency2", "dependency1", "dependency3"]
+"""
+    )
+    (tmp_path / "coversion_of_multiple_project").mkdir()
+    (tmp_path / "coversion_of_multiple_project" / "__init__.py").write_text("")
+    return tmp_path

--- a/hatch-dependency-coversion/tests/test_metadata_hook.py
+++ b/hatch-dependency-coversion/tests/test_metadata_hook.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 import pkginfo
 from .utils import build_wheel

--- a/hatch-dependency-coversion/tests/test_metadata_hook.py
+++ b/hatch-dependency-coversion/tests/test_metadata_hook.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import pkginfo
+from .utils import build_wheel
+
+
+def test_unconfigured_project_changes_nothing(
+    unconfigured_project: Path, static_requirements: list[str]
+) -> None:
+    wheelpath = build_wheel(unconfigured_project)
+    dist_metadata = pkginfo.Wheel(str(wheelpath))
+    requires = dist_metadata.requires_dist
+    assert requires == static_requirements
+
+
+def test_zero_requested_coversions_changes_nothing(
+    requests_zero_coversions_project: Path, static_requirements: list[str]
+) -> None:
+    wheelpath = build_wheel(requests_zero_coversions_project)
+    dist_metadata = pkginfo.Wheel(str(wheelpath))
+    requires = dist_metadata.requires_dist
+    assert requires == static_requirements
+
+
+def test_coversion_of_open_version_applies(
+    requests_coversion_of_open_version_project: Path, static_requirements: list[str]
+) -> None:
+    wheelpath = build_wheel(requests_coversion_of_open_version_project)
+    dist_metadata = pkginfo.Wheel(str(wheelpath))
+    requires = dist_metadata.requires_dist
+    assert sorted(requires) == ["dependency1==0.1.0"] + static_requirements[1:]
+
+
+def test_coversion_of_specified_version_applies(
+    requests_coversion_of_specified_version_project: Path,
+    static_requirements: list[str],
+) -> None:
+    wheelpath = build_wheel(requests_coversion_of_specified_version_project)
+    dist_metadata = pkginfo.Wheel(str(wheelpath))
+    requires = dist_metadata.requires_dist
+    assert (
+        sorted(requires)
+        == [static_requirements[0]] + ["dependency2==0.1.0"] + static_requirements[2:]
+    )
+
+
+def test_coversion_of_marked_version_applies(
+    requests_coversion_of_marked_version_project: Path, static_requirements: list[str]
+) -> None:
+    wheelpath = build_wheel(requests_coversion_of_marked_version_project)
+    dist_metadata = pkginfo.Wheel(str(wheelpath))
+    requires = dist_metadata.requires_dist
+    assert sorted(requires) == static_requirements[:2] + [
+        "dependency3==0.1.0; os_name == 'Windows'"
+    ]

--- a/hatch-dependency-coversion/tests/utils.py
+++ b/hatch-dependency-coversion/tests/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sys import executable
 from pathlib import Path
 from os import linesep
 import subprocess
@@ -25,7 +26,7 @@ def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
     output = output_path or proj_path / "dist"
     output.mkdir()
     cmd = [
-        "python",
+        executable,
         "-m",
         "build",
         "--no-isolation",
@@ -34,7 +35,9 @@ def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
         str(output),
         str(proj_path),
     ]
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
     stdout, stderr = proc.communicate()
     stdout_content = stdout.decode("utf-8")
     stderr_content = stderr.decode("utf-8")

--- a/hatch-dependency-coversion/tests/utils.py
+++ b/hatch-dependency-coversion/tests/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from shlex import quote
 from sys import executable
 from pathlib import Path
 from os import linesep
@@ -25,16 +26,16 @@ class SubprocFailed(Exception):
 def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
     output = output_path or proj_path / "dist"
     output.mkdir()
-    cmd = [
-        executable,
+    cmd = ' '.join([
+        quote(executable),
         "-m",
         "build",
         "--no-isolation",
         "--wheel",
         "-o",
-        str(output),
-        str(proj_path),
-    ]
+        quote(str(output)),
+        quote(str(proj_path)),
+    ])
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
@@ -43,7 +44,7 @@ def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
     stderr_content = stderr.decode("utf-8")
     if proc.returncode:
         raise SubprocFailed(
-            " ".join(cmd), proc.returncode, stdout_content, stderr_content
+            cmd, proc.returncode, stdout_content, stderr_content
         )
     for line in stdout_content.split(linesep):
         if ".whl" in line:

--- a/hatch-dependency-coversion/tests/utils.py
+++ b/hatch-dependency-coversion/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from os import linesep
 import subprocess

--- a/hatch-dependency-coversion/tests/utils.py
+++ b/hatch-dependency-coversion/tests/utils.py
@@ -26,16 +26,18 @@ class SubprocFailed(Exception):
 def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
     output = output_path or proj_path / "dist"
     output.mkdir()
-    cmd = ' '.join([
-        quote(executable),
-        "-m",
-        "build",
-        "--no-isolation",
-        "--wheel",
-        "-o",
-        quote(str(output)),
-        quote(str(proj_path)),
-    ])
+    cmd = " ".join(
+        [
+            quote(executable),
+            "-m",
+            "build",
+            "--no-isolation",
+            "--wheel",
+            "-o",
+            quote(str(output)),
+            quote(str(proj_path)),
+        ]
+    )
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
     )
@@ -43,9 +45,7 @@ def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
     stdout_content = stdout.decode("utf-8")
     stderr_content = stderr.decode("utf-8")
     if proc.returncode:
-        raise SubprocFailed(
-            cmd, proc.returncode, stdout_content, stderr_content
-        )
+        raise SubprocFailed(cmd, proc.returncode, stdout_content, stderr_content)
     for line in stdout_content.split(linesep):
         if ".whl" in line:
             for part in line.split(" "):

--- a/hatch-dependency-coversion/tests/utils.py
+++ b/hatch-dependency-coversion/tests/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from shlex import quote
 from sys import executable
 from pathlib import Path
 from os import linesep
@@ -28,14 +27,14 @@ def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
     output.mkdir()
     cmd = " ".join(
         [
-            quote(executable),
+            f'"{executable}"',
             "-m",
             "build",
             "--no-isolation",
             "--wheel",
             "-o",
-            quote(str(output)),
-            quote(str(proj_path)),
+            f'"{str(output)}"',
+            f'"{str(proj_path)}"',
         ]
     )
     proc = subprocess.Popen(

--- a/hatch-dependency-coversion/tests/utils.py
+++ b/hatch-dependency-coversion/tests/utils.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from os import linesep
+import subprocess
+
+
+def _indent(msg: str, count: int = 0) -> str:
+    lines = msg.split(linesep)
+    indent = "\t" * count
+    return indent + f"{indent}{linesep}".join(lines)
+
+
+class SubprocFailed(Exception):
+    def __init__(self, command: str, returncode: int, stdout: str, stderr: str) -> None:
+        self.message = f"Command {command} failed: {returncode}!{linesep}stdout:{linesep}{_indent(stdout, 1)}{linesep}stderr:{linesep}{_indent(stderr, 1)}"
+        self.command = command
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __repr__(self) -> str:
+        return f"<SubprocFailed command={self.command} returncode={self.returncode}>"
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
+    output = output_path or proj_path / "dist"
+    output.mkdir()
+    cmd = [
+        "python",
+        "-m",
+        "build",
+        "--no-isolation",
+        "--wheel",
+        "-o",
+        str(output),
+        str(proj_path),
+    ]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    stdout_content = stdout.decode("utf-8")
+    stderr_content = stderr.decode("utf-8")
+    if proc.returncode:
+        raise SubprocFailed(
+            " ".join(cmd), proc.returncode, stdout_content, stderr_content
+        )
+    for line in stdout_content.split(linesep):
+        if ".whl" in line:
+            for part in line.split(" "):
+                if ".whl" in part:
+                    return output / part
+    raise RuntimeError(
+        f'Failed to find wheel in stdout from {" ".join(cmd)}!{linesep}stdout:{linesep}{_indent(stdout_content)}'
+    )

--- a/hatch-dependency-coversion/tests/utils.py
+++ b/hatch-dependency-coversion/tests/utils.py
@@ -3,17 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from os import linesep
 import subprocess
-
-
-def _indent(msg: str, count: int = 0) -> str:
-    lines = msg.split(linesep)
-    indent = "\t" * count
-    return indent + f"{indent}{linesep}".join(lines)
+from textwrap import indent
 
 
 class SubprocFailed(Exception):
     def __init__(self, command: str, returncode: int, stdout: str, stderr: str) -> None:
-        self.message = f"Command {command} failed: {returncode}!{linesep}stdout:{linesep}{_indent(stdout, 1)}{linesep}stderr:{linesep}{_indent(stderr, 1)}"
+        self.message = f"Command {command} failed: {returncode}!{linesep}stdout:{linesep}{indent(stdout, '    ')}{linesep}stderr:{linesep}{indent(stderr, '    ')}"
         self.command = command
         self.returncode = returncode
         self.stdout = stdout
@@ -53,5 +48,5 @@ def build_wheel(proj_path: Path, output_path: Path | None = None) -> Path:
                 if ".whl" in part:
                     return output / part
     raise RuntimeError(
-        f'Failed to find wheel in stdout from {" ".join(cmd)}!{linesep}stdout:{linesep}{_indent(stdout_content)}'
+        f'Failed to find wheel in stdout from {" ".join(cmd)}!{linesep}stdout:{linesep}{indent(stdout_content, "    ")}'
     )


### PR DESCRIPTION
hatch-dependency-coversion is a hatch plugin that allows specifying project dependencies (the ones that will be in distribution metadata) as dynamically exactly coversioned with the project itself. This is useful for projects that are deployed as part of a monorepo but as independent packages.
