### PR TITLE
Fix pull-request-target changelog requirements

### DIFF
--- a/.github/workflows/pull-request-checking.yml
+++ b/.github/workflows/pull-request-checking.yml
@@ -28,10 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [which-paths]
     steps:
-      - name: What
-        run: |
-          echo ${{ needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF }}
-          echo ${{ contains(needs.which-paths.outputs.HATCHV_CS_TUNABLE_DIFF, 'hatch_vcs_tunable') }}
       - name: Ask for news fragments
         if: ${{ !contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'changelog.d') }}
         run: |

--- a/.github/workflows/pull-request-checking.yml
+++ b/.github/workflows/pull-request-checking.yml
@@ -1,6 +1,6 @@
 name: 'pull request checking'
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -24,9 +24,9 @@ jobs:
         run: |
           echo "HATCH_VCS_TUNABLE_DIFF=\"${GIT_DIFF_FILTERED}\"" >> $GITHUB_OUTPUT
   hatch-vcs-tunable-analysis:
+    if: ${{ contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'hatch_vcs_tunable')}}
     runs-on: ubuntu-latest
     needs: [which-paths]
-    if: ${{ contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'hatch_vcs_tunable')}}
     steps:
       - name: What
         run: |

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -26,7 +26,7 @@ jobs:
   hatch-vcs-tunable-analysis:
     runs-on: ubuntu-latest
     needs: [which-paths]
-    if: ${{ needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF }}
+    if: ${{ contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'hatch_vcs_tunable')}}
     steps:
       - name: Ask for news fragments
         if: ${{ !contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'changelog.d') }}

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -28,6 +28,10 @@ jobs:
     needs: [which-paths]
     if: ${{ contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'hatch_vcs_tunable')}}
     steps:
+      - name: What
+        run: |
+          echo ${{ needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF }}
+          echo ${{ contains(needs.which-paths.outputs.HATCHV_CS_TUNABLE_DIFF, 'hatch_vcs_tunable') }}
       - name: Ask for news fragments
         if: ${{ !contains(needs.which-paths.outputs.HATCH_VCS_TUNABLE_DIFF, 'changelog.d') }}
         run: |


### PR DESCRIPTION
I implemented a workflow to check whether a pull request had a news fragment but I did it with `pull_request_target`, which doesn't have access to the code from the PR. It's really just for doing surface level checks of PRs that you can always trust to run. Make it a normal `pull_request` trigger.