### PR TITLE
add deploy workflow for hatch-vcs-tunable

### DIFF
--- a/.github/workflows/publish-hatch-vcs-tunable.yml
+++ b/.github/workflows/publish-hatch-vcs-tunable.yml
@@ -1,4 +1,4 @@
-name: 'publish release'
+name: 'publish hatch-vcs-tunable'
 on:
   push:
     tags:

--- a/.github/workflows/publish-hatch-vcs-tunable.yml
+++ b/.github/workflows/publish-hatch-vcs-tunable.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment:
-      name: hatch-vcs-tunable-release
+      name: hatch-vcs-tunable-pypi-release
       url: https://pypi.org/p/hatch-vcs-tunable
     permissions:
       id-token: write

--- a/.github/workflows/publish-hatch-vcs-tunable.yml
+++ b/.github/workflows/publish-hatch-vcs-tunable.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Build distribution
       run: |
+        python -m pip install hatch
         hatch build
       working-directory:
         hatch-vcs-tunable

--- a/.github/workflows/publish-hatch-vcs-tunable.yml
+++ b/.github/workflows/publish-hatch-vcs-tunable.yml
@@ -1,0 +1,26 @@
+name: 'publish release'
+on:
+  push:
+    tags:
+      - 'hatch-vcs-tunable@*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: hatch-vcs-tunable-release
+      url: https://pypi.org/p/hatch-vcs-tunable
+    permissions:
+      id-token: write
+    steps:
+    - name: Fetch source for package build
+      uses: actions/checkout@v3
+    - name: Build distribution
+      run: |
+        hatch build
+      working-directory:
+        hatch-vcs-tunable
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: hatch-vcs-tunable/dist


### PR DESCRIPTION
This will use tags that match a prefix pattern to trigger a deploy to pypi, using the pypi trusted deploy OIDC connector (configuration is on pypi's side) to do so without needing to save credentials.
