### PR TITLE
build: install hatch to dependency-coversion build

### DIFF
--- a/.github/workflows/publish-hatch-dependency-coversion.yml
+++ b/.github/workflows/publish-hatch-dependency-coversion.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Build distribution
       run: |
+        python -m install hatch
         hatch build
       working-directory:
         hatch-dependency-coversion

--- a/.github/workflows/publish-hatch-dependency-coversion.yml
+++ b/.github/workflows/publish-hatch-dependency-coversion.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: hatch-dependency-coversion-pypi-release
-      url: https://pypi.org/p/hatch-dependency-tunable
+      url: https://pypi.org/p/hatch-dependency-coversion
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/publish-hatch-dependency-coversion.yml
+++ b/.github/workflows/publish-hatch-dependency-coversion.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Build distribution
       run: |
-        python -m install hatch
+        python -m pip install hatch
         hatch build
       working-directory:
         hatch-dependency-coversion


### PR DESCRIPTION
As with the vcs-tunable workflow, we need to install hatch before building with it.