### PR TITLE
Fix versioning

### DIFF
--- a/hatch-dependency-coversion/pyproject.toml
+++ b/hatch-dependency-coversion/pyproject.toml
@@ -39,7 +39,7 @@ Changelog = "https://github.com/Opentrons/hatch-plugins/tree/main/hatch-dependen
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "0.0.0-dev"
-tag-pattern = "hatch-dependency-coversion@(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+(\\.(a(lpha-)?|b(eta-)?)[0-9]+)?)"
+tag-pattern = "hatch-dependency-coversion@(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+((a|b|\\.alpha-|\\.beta-)[0-9]+)?)"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/hatch_dependency_coversion/_version.py"

--- a/hatch-dependency-coversion/pyproject.toml
+++ b/hatch-dependency-coversion/pyproject.toml
@@ -39,10 +39,14 @@ Changelog = "https://github.com/Opentrons/hatch-plugins/tree/main/hatch-dependen
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "0.0.0-dev"
-tag-pattern = "hatch-dependency-coversion@(?P<version>)"
+tag-pattern = "hatch-dependency-coversion@(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+(\\.(a(lpha-)?|b(eta-)?)[0-9]+)?)"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/hatch_dependency_coversion/_version.py"
+
+[tool.hatch.version.raw-options]
+git_describe_command = "git describe --dirty --tags --long --match hatch-dependency-coversion@*"
+root = "../"
 
 [tool.hatch.envs.maintenance]
 dependencies = [

--- a/hatch-vcs-tunable/pyproject.toml
+++ b/hatch-vcs-tunable/pyproject.toml
@@ -41,7 +41,7 @@ Changelog = "https://github.com/Opentrons/hatch-plugins/tree/main/hatch-vcs-tuna
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "0.0.0-dev"
-tag-pattern = "hatch-vcs-tunable@(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+(\\.(a(lpha-)?|b(eta-)?)[0-9]+)?)"
+tag-pattern = "hatch-vcs-tunable@(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+((a|b|\\.alpha-|\\.beta-)[0-9]+)?)"
 
 [tool.hatch.build.hooks.vcs]
 version-file="src/hatch_vcs_tunable/_version.py"

--- a/hatch-vcs-tunable/pyproject.toml
+++ b/hatch-vcs-tunable/pyproject.toml
@@ -41,10 +41,14 @@ Changelog = "https://github.com/Opentrons/hatch-plugins/tree/main/hatch-vcs-tuna
 [tool.hatch.version]
 source = "vcs"
 fallback-version = "0.0.0-dev"
-tag-pattern = 'hatch-vcs-tunable@(?P<version>)'
+tag-pattern = "hatch-vcs-tunable@(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+(\\.(a(lpha-)?|b(eta-)?)[0-9]+)?)"
 
 [tool.hatch.build.hooks.vcs]
 version-file="src/hatch_vcs_tunable/_version.py"
+
+[tool.hatch.version.raw-options]
+git_describe_command = "git describe --dirty --tags --long --match hatch-vcs-tunable@*"
+root = "../"
 
 [tool.hatch.envs.maintenance]
 dependencies = [


### PR DESCRIPTION
We need to specify version metadata in this special annoying way where we specify the git describe command as well as the regex to find versions within the tag names.