### PR TITLE
update to hatchling 1.29

### DIFF
--- a/hatch-dependency-coversion/changelog.d/2-update-hatchling-version.md
+++ b/hatch-dependency-coversion/changelog.d/2-update-hatchling-version.md
@@ -1,0 +1,5 @@
+# Updated to hatchling 1.29
+
+This raises the default metadata version to 2.4 which allows License-Expression.
+
+

--- a/hatch-dependency-coversion/pyproject.toml
+++ b/hatch-dependency-coversion/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.21.1", "hatch-vcs==0.4.0"]
+requires = ["hatchling==1.27.0", "hatch-vcs==0.4.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/hatch-vcs-tunable/changelog.d/3-updated-hatchling-version.md
+++ b/hatch-vcs-tunable/changelog.d/3-updated-hatchling-version.md
@@ -1,0 +1,4 @@
+# Updated to hatchling 1.29
+
+This raises the default metadata version to 2.4 which allows License-Expression.
+

--- a/hatch-vcs-tunable/pyproject.toml
+++ b/hatch-vcs-tunable/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling==1.21.1", "hatch-vcs==0.4.0"]
+requires = ["hatchling==1.27.0", "hatch-vcs==0.4.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
This allows metadata 2.4 which allows License-Expression.

