### PR TITLE
hatch-dependency-coversion: handle optional deps

### DIFF
--- a/hatch-dependency-coversion/changelog.d/3-handle-optional-dependencies.md
+++ b/hatch-dependency-coversion/changelog.d/3-handle-optional-dependencies.md
@@ -1,0 +1,4 @@
+# Handle optional dependencies
+
+Also update any optional dependencies if they're present in the plugin config.
+

--- a/hatch-dependency-coversion/tests/conftest.py
+++ b/hatch-dependency-coversion/tests/conftest.py
@@ -160,3 +160,32 @@ def requests_multiple_project(tmp_path: Path, static_requirements: list[str]) ->
     (tmp_path / "coversion_of_multiple_project").mkdir()
     (tmp_path / "coversion_of_multiple_project" / "__init__.py").write_text("")
     return tmp_path
+
+
+@pytest.fixture
+def requests_coversion_of_optional_dependency_project(
+    tmp_path: Path, static_requirements: list[str]
+) -> Path:
+    (tmp_path / "pyproject.toml").write_text(
+        dedent(
+            f"""
+        [build-system]
+        requires = ["hatchling", "hatch-dependency-coversion"]
+        build-backend = "hatchling.build"
+        [project]
+        name = "coversion-of-optional-dependency-project"
+        version = "0.1.0"
+        dependencies = [{','.join([f'"{requirement}"' for requirement in static_requirements[1:]])}]
+        dynamic = ['dependency-coversion']
+        [project.optional-dependencies]
+        extra1 = [{f'"{static_requirements[0]}"'}]
+        [tool.hatch.metadata.hooks.dependency-coversion]
+        override-versions-of=["dependency1"]
+            """
+        )
+    )
+    (tmp_path / "coversion_of_optional_dependency_project").mkdir()
+    (tmp_path / "coversion_of_optional_dependency_project" / "__init__.py").write_text(
+        ""
+    )
+    return tmp_path

--- a/hatch-dependency-coversion/tests/test_metadata_hook.py
+++ b/hatch-dependency-coversion/tests/test_metadata_hook.py
@@ -53,3 +53,16 @@ def test_coversion_of_marked_version_applies(
     assert sorted(requires) == static_requirements[:2] + [
         "dependency3==0.1.0; os_name == 'Windows'"
     ]
+
+
+def test_coversion_of_optional_dependency_applies(
+    requests_coversion_of_optional_dependency_project: Path,
+    static_requirements: list[str],
+) -> None:
+    wheelpath = build_wheel(requests_coversion_of_optional_dependency_project)
+    dist_metadata = pkginfo.Wheel(str(wheelpath))
+    requires = dist_metadata.requires_dist
+    assert (
+        sorted(requires)
+        == ["dependency1==0.1.0; extra == 'extra1'"] + static_requirements[1:]
+    )


### PR DESCRIPTION
They're in a different part of the metadata.
