### PR TITLE
hatch-vcs-tunable: chore(docs): update badge URL and add uvx tip

### DIFF
--- a/hatch-vcs-tunable/CONTRIBUTORS.md
+++ b/hatch-vcs-tunable/CONTRIBUTORS.md
@@ -1,7 +1,9 @@
 # Contributors to hatch-vcs-tunable
 
 ## Maintainers
+
 - [Seth Foster](https://github.com/sfoster1)
 
 ## Developers
 
+- [Josh McVey](https://github.com/joshmcvey)

--- a/hatch-vcs-tunable/CONTRIBUTORS.md
+++ b/hatch-vcs-tunable/CONTRIBUTORS.md
@@ -6,4 +6,4 @@
 
 ## Developers
 
-- [Josh McVey](https://github.com/joshmcvey)
+- [Josh McVey](https://github.com/y3rsh)

--- a/hatch-vcs-tunable/DEVELOPING.md
+++ b/hatch-vcs-tunable/DEVELOPING.md
@@ -20,7 +20,7 @@ Pull requests should contain
 Static analysis tools are run from the default hatch environment. Typechecking is via [mypy](http://mypy-lang.org/), linting and formatting is via [ruff](https://github.com/astral-sh/ruff). You can run these commands with `hatch run` without further qualification:
 
 > [!TIP]
-> Easily use hatch with [uv](https://github.com/astral-sh/uv)
+> Easily use hatch with [uv](https://github.com/astral-sh/uv).
 > All commands below can be run prepending `uvx` to the command, e.g. `uvx hatch run check`
 > Even `uvx hatch run test:test` runs seamlessly
 

--- a/hatch-vcs-tunable/DEVELOPING.md
+++ b/hatch-vcs-tunable/DEVELOPING.md
@@ -4,11 +4,12 @@
 
 ## Contributing
 
-Contributions should come through pull request. If done via a fork, a maintainer will run the CI checks after a quick review. Open source contributions are welcome! 
+Contributions should come through pull request. If done via a fork, a maintainer will run the CI checks after a quick review. Open source contributions are welcome!
 
 Pull requests should contain
+
 - A descriptive title
-   - that is prefixed with `hatch-vcs-tunable:`, since this repository has multiple packages
+  - that is prefixed with `hatch-vcs-tunable:`, since this repository has multiple packages
 - A descriptive body that notes what the problem/missing feature is that the PR fixes and how the PR fixes it
 - A note on how the PR should be tested, if testing is required, and descriptions of how you tested it
 - A news fragment in `changelog.d` that adheres to [towncrier news fragment format](https://towncrier.readthedocs.io/en/stable/tutorial.html#creating-news-fragments) describing your change
@@ -17,6 +18,12 @@ Pull requests should contain
 ## Linting/formatting/typechecking
 
 Static analysis tools are run from the default hatch environment. Typechecking is via [mypy](http://mypy-lang.org/), linting and formatting is via [ruff](https://github.com/astral-sh/ruff). You can run these commands with `hatch run` without further qualification:
+
+> [!TIP]
+> Easily use hatch with [uv](https://github.com/astral-sh/uv)
+> All commands below can be run prepending `uvx` to the command, e.g. `uvx hatch run check`
+> Even `uvx hatch run test:test` runs seamlessly
+
 - Typecheck: `hatch run check`
 - Format: `hatch run format`
 - Lint: `hatch run lint`
@@ -36,5 +43,4 @@ Tests must pass in CI before a PR can be merged.
 ## Maintenance and Releasing
 
 Changelogs are generated using [towncrier](https://towncrier.readthedocs.io/en/stable/index.html). When opening a PR that has a newsworthy change, that PR should include a news fragment in `changelog.d`. Changelog generation happens during the release flow, which is automated via github actions that can be run by project maintainers.
-
 

--- a/hatch-vcs-tunable/README.md
+++ b/hatch-vcs-tunable/README.md
@@ -1,10 +1,9 @@
 # hatch-vcs-tunable
 
-[![PyPI - Version](https://img.shields.io/pypi/v/hatch-git-version-tunable.svg)](https://pypi.org/project/hatch-vcs-tunable)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hatch-git-version-tunable.svg)](https://pypi.org/project/hatch-vcs-tunable)
+[![PyPI - Version](https://img.shields.io/pypi/v/hatch-vcs-tunable.svg)](https://pypi.org/project/hatch-vcs-tunable)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hatch-vcs-tunable.svg)](https://pypi.org/project/hatch-vcs-tunable)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
-
 
 -----
 
@@ -12,11 +11,16 @@ This is a plugin for [Hatch](https://github.com/pypa/hatch) that extends the plu
 
 The reason you might want to do this is if you have multiple release tracks for your package, or multiple contexts in which it is used, and want to give it different versions in those different contexts.
 
-**Table of Contents**
+## **Table of Contents**
 
-- [Use as a plugin](#plugin)
-- [Configuration](#Configuration)
-- [License](#license)
+- [hatch-vcs-tunable](#hatch-vcs-tunable)
+  - [**Table of Contents**](#table-of-contents)
+  - [Plugin](#plugin)
+  - [Configuration](#configuration)
+    - [`pyproject.toml`](#pyprojecttoml)
+    - [Environment](#environment)
+      - [`raw-options`](#raw-options)
+  - [License](#license)
 
 ## Plugin
 
@@ -44,6 +48,7 @@ version-file="_version.py"
 ### Environment
 
 The environment variables should be specified as `ALL_CAPS_UNDERSCORE` versions of the pyproject settings, prefixed with `HATCH_VCS_TUNABLE_`. So for instance,
+
 - `tag-pattern` can be specified as `HATCH_VCS_TUNABLE_TAG_PATTERN`
 - `fallback-version` can be specified as `HATCH_VCS_TUNABLE_FALLBACK_VERSION`
 
@@ -54,7 +59,6 @@ The value of the `raw-options` is passed directly to `setuptools_scm`. It may ha
 If a setting is specified both in the environment and in `pyproject.toml`, the environment variable will take priority.
 
 Environment variables that are specified as empty still exist, so if you do `HATCH_VCS_TUNABLE_FALLBACK_VERSION=  hatch build`, the fallback version will be the empty string. If you have one of these environment variables defined all the time and need to remove it, use `unset`.
-
 
 ## License
 


### PR DESCRIPTION
# Overview

Update the badge URLs, format a little, and add a tip about using `uvx` to easily dev on the project.
